### PR TITLE
Remove internal copy of libiconv on osx since causes failed linking.

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,6 +5,11 @@ set -e -o pipefail -x
 BINARY_HOME=${PREFIX}/bin
 PACKAGE_HOME=${PREFIX}/share/${PKG_NAME}-${PKG_VERSION}-${PKG_BUILDNUM}
 
+# libiconv causes linkage conflicts on OSX
+if conda info | grep -q 'platform : osx'; then
+  rm -vf ${PREFIX}/lib/libiconv*
+fi
+
 mkdir -p ${BINARY_HOME}
 mkdir -p ${PACKAGE_HOME}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,8 +12,8 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 2
-  skip: True  # [win or osx]
+  number: 3
+  skip: True  # [win]
 
 requirements:
   build:


### PR DESCRIPTION
Boosted build number for consistency since build.sh was changed

TODOs:
- [ ] regenerate CI templates so it would build for osx
- [ ] figure out libtinfo issue -- which came up during local build

intends to fix #7 