### PR TITLE
Remove build-time components from run-time requirements.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 2
+  number: 3
   skip: True  # [win or osx]
 
 requirements:
@@ -33,7 +33,6 @@ requirements:
     - sqlite 3.20.*
     - chrpath  # [linux]
   run:
-    - toolchain
     - perl
     - git >=2
     - rsync
@@ -45,7 +44,6 @@ requirements:
     - gnutls
     - libxml2 2.9.*
     - sqlite 3.20.*
-    - chrpath  # [linux]
 
 about:
   home: https://git-annex.branchable.com


### PR DESCRIPTION
Removes `toolchain` and `chrpath` from runtime dependencies of `git-annex` packages. These appear to be build-time requirements that leaking into the runtime requirements list. 

Critically, the `toolchain` package is a conda-forge package that configures the compiler environment and should *not* be added to a runtime env.

I haven't fully audited which packages in the current runtime list are actually required, but these deletions are enough to get the package into a sane state.