### PR TITLE
MNT: Re-rendered with conda-build 3.17.7, conda-smithy 3.2.9, and con…

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -1,3 +1,7 @@
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+# -*- mode: yaml -*-
+
 jobs:
 - job: linux_64
   pool:
@@ -8,11 +12,20 @@ jobs:
     matrix:
       linux_:
         CONFIG: linux_
+        UPLOAD_PACKAGES: False
   steps:
   - script: |
       sudo pip install --upgrade pip
       sudo pip install setuptools shyaml
     displayName: Install dependencies
+
+  # configure qemu binfmt-misc running.  This allows us to run docker containers 
+  # embedded qemu-static
+  - script: |
+      docker run --rm --privileged multiarch/qemu-user-static:register
+      ls /proc/sys/fs/binfmt_misc/
+    condition: not(startsWith(variables['CONFIG'], 'linux_64'))
+    displayName: Configure binfmt_misc
 
   - script: .azure-pipelines/run_docker_build.sh
     displayName: Run docker build

--- a/.azure-pipelines/build_steps.sh
+++ b/.azure-pipelines/build_steps.sh
@@ -24,15 +24,15 @@ conda install --yes --quiet conda-forge-ci-setup=2 conda-build -c conda-forge
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
-# A lock sometimes occurs with incomplete builds. The lock file is stored in build_artifacts.
-conda clean --lock
-
-run_conda_forge_build_setup# make the build number clobber
+run_conda_forge_build_setup
+# make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
     --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
 
-
+if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
+    upload_package "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
+fi
 
 touch "/home/conda/feedstock_root/build_artifacts/conda-forge-build-done-${CONFIG}"

--- a/.azure-pipelines/run_docker_build.sh
+++ b/.azure-pipelines/run_docker_build.sh
@@ -33,7 +33,7 @@ if [ -z "$CONFIG" ]; then
 fi
 
 pip install shyaml
-DOCKER_IMAGE=$(cat "${FEEDSTOCK_ROOT}/.ci_support/${CONFIG}.yaml" | shyaml get-value docker_image.0 condaforge/linux-anvil )
+DOCKER_IMAGE=$(cat "${FEEDSTOCK_ROOT}/.ci_support/${CONFIG}.yaml" | shyaml get-value docker_image.0 condaforge/linux-anvil-comp7 )
 
 mkdir -p "$ARTIFACTS"
 DONE_CANARY="$ARTIFACTS/conda-forge-build-done-${CONFIG}"
@@ -41,13 +41,14 @@ rm -f "$DONE_CANARY"
 # Not all providers run with a real tty.  Disable using one
 DOCKER_RUN_ARGS=" "
 
-
+export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
 docker run ${DOCKER_RUN_ARGS} \
            -v "${RECIPE_ROOT}":/home/conda/recipe_root:ro,z \
            -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z \
            -e CONFIG \
            -e BINSTAR_TOKEN \
            -e HOST_USER_ID \
+           -e UPLOAD_PACKAGES \
            $DOCKER_IMAGE \
            bash \
            /home/conda/feedstock_root/${PROVIDER_DIR}/build_steps.sh

--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -1,13 +1,13 @@
 c_compiler:
-- toolchain_c
+- gcc
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- toolchain_cxx
+- gxx
 docker_image:
-- condaforge/linux-anvil
+- condaforge/linux-anvil-comp7
 gmp:
 - '6'
 libffi:

--- a/.circleci/build_steps.sh
+++ b/.circleci/build_steps.sh
@@ -24,9 +24,6 @@ conda install --yes --quiet conda-forge-ci-setup=2 conda-build -c conda-forge
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
-# A lock sometimes occurs with incomplete builds. The lock file is stored in build_artifacts.
-conda clean --lock
-
 source run_conda_forge_build_setup
 
 # make the build number clobber
@@ -35,8 +32,8 @@ make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
     --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
 
-
-upload_package "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
-
+if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
+    upload_package "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
+fi
 
 touch "/home/conda/feedstock_root/build_artifacts/conda-forge-build-done-${CONFIG}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,7 @@
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+# -*- mode: yaml -*-
+
 version: 2
 
 jobs:
@@ -14,7 +18,7 @@ jobs:
             ./.circleci/fast_finish_ci_pr_build.sh
             ./.circleci/checkout_merge_commit.sh
       - run:
-          command: docker pull condaforge/linux-anvil
+          command: docker pull condaforge/linux-anvil-comp7
       - run:
           # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
           command: ./.circleci/run_docker_build.sh

--- a/.circleci/fast_finish_ci_pr_build.sh
+++ b/.circleci/fast_finish_ci_pr_build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-curl https://raw.githubusercontent.com/conda-forge/conda-forge-ci-setup-feedstock/branch2.0/recipe/conda_forge_ci_setup/ff_ci_pr_build.py | \
+curl https://raw.githubusercontent.com/conda-forge/conda-forge-ci-setup-feedstock/master/recipe/conda_forge_ci_setup/ff_ci_pr_build.py | \
      python - -v --ci "circle" "${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}" "${CIRCLE_BUILD_NUM}" "${CIRCLE_PR_NUMBER}"

--- a/.circleci/run_docker_build.sh
+++ b/.circleci/run_docker_build.sh
@@ -33,7 +33,7 @@ if [ -z "$CONFIG" ]; then
 fi
 
 pip install shyaml
-DOCKER_IMAGE=$(cat "${FEEDSTOCK_ROOT}/.ci_support/${CONFIG}.yaml" | shyaml get-value docker_image.0 condaforge/linux-anvil )
+DOCKER_IMAGE=$(cat "${FEEDSTOCK_ROOT}/.ci_support/${CONFIG}.yaml" | shyaml get-value docker_image.0 condaforge/linux-anvil-comp7 )
 
 mkdir -p "$ARTIFACTS"
 DONE_CANARY="$ARTIFACTS/conda-forge-build-done-${CONFIG}"
@@ -41,13 +41,14 @@ rm -f "$DONE_CANARY"
 # Enable running in interactive mode attached to a tty
 DOCKER_RUN_ARGS=" -it "
 
-
+export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
 docker run ${DOCKER_RUN_ARGS} \
            -v "${RECIPE_ROOT}":/home/conda/recipe_root:ro,z \
            -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z \
            -e CONFIG \
            -e BINSTAR_TOKEN \
            -e HOST_USER_ID \
+           -e UPLOAD_PACKAGES \
            $DOCKER_IMAGE \
            bash \
            /home/conda/feedstock_root/${PROVIDER_DIR}/build_steps.sh

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
+<!--
+# -*- mode: jinja -*-
+-->
+
 About git-annex
 ===============
-
-[![Powered by NumFOCUS](https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](http://numfocus.org)
 
 Home: https://git-annex.branchable.com
 
@@ -52,6 +54,8 @@ conda search git-annex --channel conda-forge
 
 About conda-forge
 =================
+
+[![Powered by NumFOCUS](https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](http://numfocus.org)
 
 conda-forge is a community-led conda channel of installable packages.
 In order to provide high-quality builds, the process has been automated into the

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,4 +1,6 @@
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+# -*- mode: yaml -*-
+
 jobs:
   - template: ./.azure-pipelines/azure-pipelines-linux.yml
-
-  

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - 0001-add-magic-and-sandi.patch
 
 build:
-  number: 1
+  number: 1000
   skip: True  # [win or osx]
 
 requirements:

--- a/yum_requirements.txt
+++ b/yum_requirements.txt
@@ -1,0 +1,1 @@
+gmp-devel


### PR DESCRIPTION
…da-forge-pinning 2019.01.21; set build number to 1000

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
