### PR TITLE
downstream test against newer datalad 0.14.7 (not 0.14.3)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -134,7 +134,7 @@ test:
     - git-annex test
   downstreams:
     - annexremote
-    - datalad=0.14.3
+    - datalad=0.14.7
 
 about:
   home: https://git-annex.branchable.com


### PR DESCRIPTION
Decided not to bother with the other flavor of build for now since can't even get that target version and whatever is reported in the logs doesn't correspond to anything really : https://git-annex.branchable.com/bugs/downloads.kitenet.net_do_not_correspond_in_version/?updated

Making it a draft since I didn't even bother to boost build for now -- just want to see if downstream testing passes