### PR TITLE
ENH: "not nodep" build - add versioned gnupg to "run" depends

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -77,39 +77,39 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - stack
-    - perl
-    - coreutils
-    - binutils
-    - findutils
-    - pkg-config
-    - xz
-    - make
-    - automake
     - autoconf
-    - libtool
+    - automake
+    - binutils
     - bzip2
-    - ncurses
+    - coreutils
+    - findutils
     - libffi
+    - libtool
     - libxml2
-  host:
-    - gmp
-    - zlib
+    - make
     - ncurses
-    - libmagic
-    - sqlite
+    - perl
+    - pkg-config
+    - stack
+    - xz
+  host:
     - dbus
+    - gmp
     - libffi
     - libiconv
-    - openssh
+    - libmagic
     - lsof
+    - ncurses
+    - openssh
     - rsync
+    - sqlite
+    - zlib
   run:
-    - rsync
-    - git >=2.22
     - curl
-    - openssh
+    - git >=2.22
     - lsof
+    - openssh
+    - rsync
 {% endif %}
 
 {% if nodep %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@
 {% set nodep = True %}  # [nodep]
 {% set nodep = False %}  # [not nodep]
 
-{% set build = 1 %}  # [not nodep]
+{% set build = 2 %}  # [not nodep]
 {% set build = 1 %}  # [nodep]
 # prioritize non-nodep variant via build number
 {% if not nodep %}
@@ -107,6 +107,7 @@ requirements:
   run:
     - curl
     - git >=2.22
+    - gnupg >=2.1.1
     - lsof
     - openssh
     - rsync


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

First commit is just "maintenance" -- the 2nd one does the drill:

    Elderly systems might have system-wide gnupg which is not compatible with
    git-annex, as e.g. missing --kill option (if I got it right, added in 2.1.1 or
    slightly before, CentoOS used in the wild found with 2.0.22 and lacking
    it)
