### PR TITLE
deprioritize standalone more via track_features

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,7 @@
 {% set nodep = True %}  # [nodep]
 {% set nodep = False %}  # [not nodep]
 
-{% set build = 0 %}
+{% set build = 1 %}
 # prioritize non-nodep variant via build number
 {% if not nodep %}
 {% set build = build + 100 %}
@@ -106,6 +106,11 @@ build:
   skip: True  # [not linux]
   string: "alldep_h{{ PKG_HASH }}_{{ build }}"  # [not nodep]
   script: ${RECIPE_DIR}/build_nodepFalse.sh
+  # Tracked features also de-prioritize that build
+  # https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#track-features
+  # and we want to de-prioritize standalone build (it is slower etc)
+  track_features:
+    - standalone  # [nodep]
 
 requirements:
   build:


### PR DESCRIPTION
More info at https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#track-features

Pursuing addressing https://github.com/conda-forge/git-annex-feedstock/issues/136 where we see standalone build installed over a "proper" one