### PR TITLE
Update git-annex builds to 10.20230126 version

### DIFF
--- a/.ci_support/linux_64_nodepFalse.yaml
+++ b/.ci_support/linux_64_nodepFalse.yaml
@@ -3,7 +3,7 @@ bzip2:
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,7 +15,7 @@ curl:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 dbus:
 - '1'
 docker_image:
@@ -27,7 +27,7 @@ libffi:
 libiconv:
 - '1'
 libxml2:
-- '2.9'
+- '2.10'
 ncurses:
 - '6'
 nodep:

--- a/.ci_support/linux_64_nodepTrue.yaml
+++ b/.ci_support/linux_64_nodepTrue.yaml
@@ -3,7 +3,7 @@ bzip2:
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos6
 channel_sources:
@@ -15,7 +15,7 @@ curl:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 dbus:
 - '1'
 docker_image:
@@ -27,7 +27,7 @@ libffi:
 libiconv:
 - '1'
 libxml2:
-- '2.9'
+- '2.10'
 ncurses:
 - '6'
 nodep:

--- a/.ci_support/migrations/libffi34.yaml
+++ b/.ci_support/migrations/libffi34.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-libffi:
-- '3.4'
-migrator_ts: 1630622620.3080156

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 # This file was generated automatically from conda-smithy. To update this configuration,
 # update the conda-forge.yml and/or the recipe/meta.yaml.
-# -*- mode: yaml -*-
+# -*- mode: jinja-yaml -*-
 
 version: 2
 

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -33,9 +33,9 @@ CONDARC
 
 
 mamba install --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/README.md
+++ b/README.md
@@ -40,14 +40,14 @@ Current build status
               <td>linux_64_nodepFalse</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5002&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/git-annex-feedstock?branchName=main&jobName=linux&configuration=linux_64_nodepFalse" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/git-annex-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_nodepFalse" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>linux_64_nodepTrue</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5002&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/git-annex-feedstock?branchName=main&jobName=linux&configuration=linux_64_nodepTrue" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/git-annex-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_nodepTrue" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/build_nodepFalse.sh
+++ b/recipe/build_nodepFalse.sh
@@ -111,6 +111,10 @@ df
 echo "========CHECKING FREE SPACE==========="
 df .
 
+# To overcome "error: possibly undefined macro: _AC_PROG_CC_C99" due to too new autoconf
+# Workaround from https://gitlab.haskell.org/ghc/ghc/-/commit/ad2ef3a13f1eb000eab8e3d64592373b91a52806 :
+sed -i -e 's,_AC_PROG_CC_C99,AC_PROG_CC_C99,g' aclocal.m4
+
 ./boot
 ./configure --prefix=${GHC_SRC_PREFIX}  --with-gmp-includes=$PREFIX/include --with-gmp-libraries=$PREFIX/lib --with-system-libffi
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,14 +19,15 @@
 # the standard version, but in practice has the same functionality -- see discussion here:
 # https://git-annex.branchable.com/forum/standalone_tarballs_for_specific_versions/#comment-d15b771fb5d23ce0c8dfb7f1c25064c5
 #
-{% set version = "10.20220927" %}  # [not nodep]
-{% set version = "10.20220927" %}  # [nodep]
+{% set version = "10.20230126" %}  # [not nodep]
+# it is 10.20230126~5 from the same day
+{% set version = "10.20230126" %}  # [nodep]
 {% set version_printed = version %}  # [not nodep]
-{% set version_printed = version %}  # [nodep]
+{% set version_printed = "10.20221213-ge5b6b7b5e" %}  # [nodep]
 
-{% set sha256 = "8cdeff4de54bd861949616ff1cb54338f87f7aa93e8297fe88e61dc25b530caf" %}  # [not nodep]
-{% set sha256 = "14e12b3b041d077e9198a60747fd04579e5613a15aadd385465220229b78eea9" %}  # [nodep]
-{% set size = "51600480" %}  # [nodep]
+{% set sha256 = "f5b2c8561cf9085e1d0de0aba2215e7c6b50e2afb597c3263d3ff606a47d6519" %}  # [not nodep]
+{% set sha256 = "3400215acc1f7f052351d60d17603b36c1338d743b9d8a700eead3dfcd52ad92" %}  # [nodep]
+{% set size = "53868494" %}  # [nodep]
 
 {% set nodep = True %}  # [nodep]
 {% set nodep = False %}  # [not nodep]


### PR DESCRIPTION
Closes #152
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

for the standalone I figured it was the `10.20221213-ge5b6b7b5e` which is `10.20230126~5` and I left its version to be as of the released one although indeed comes 5 commits before:

```shell
❯ git diff 10.20230126~5..10.20230126 --stat
 CHANGELOG                         |  4 ++--
 doc/install/Linux_standalone.mdwn |  3 +--
 doc/news/version_10.20220822.mdwn | 27 ---------------------------
 doc/news/version_10.20230126.mdwn | 27 +++++++++++++++++++++++++++
 git-annex.cabal                   |  6 +++---
 5 files changed, 33 insertions(+), 34 deletions(-)
```